### PR TITLE
Adding support for .NET Core 3.0

### DIFF
--- a/src/XAMLMarkupExtensions.csproj
+++ b/src/XAMLMarkupExtensions.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<TargetFrameworks>net452;net40;net35;netcoreapp3.0</TargetFrameworks>
 		<AssemblyTitle>XAMLMarkupExtensions</AssemblyTitle>
@@ -27,6 +27,7 @@
 		<DelaySign>false</DelaySign>
 		<PublicSign>true</PublicSign>
 		<AssemblyOriginatorKeyFile>public.snk</AssemblyOriginatorKeyFile>
+		<UseWpf>True</UseWpf>
 	</PropertyGroup>
 
 	<Choose>
@@ -43,18 +44,8 @@
 	</Choose>
 
 	<ItemGroup>
-		<Reference Include="PresentationCore" />
-		<Reference Include="PresentationFramework" />
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="System.Drawing" />
-		<Reference Condition="'$(TargetFramework)' != 'net35'" Include="System.Xaml" />
-		<Reference Include="System.Xml.Linq" />
-		<Reference Include="System.Xml" />
-		<Reference Include="WindowsBase" />
-
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
-		<PackageReference Include="GitVersionTask" Version="5.1.1" PrivateAssets="All" />
+		<PackageReference Include="GitVersionTask" Version="4.0.0" PrivateAssets="All" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
 	</ItemGroup>
 
 	<Target Name="PublishToNugetWithAPIKey" AfterTargets="GenerateNuspec" Condition="Exists('$(SolutionDir)\..\..\nugetapikey.txt')">

--- a/tests/TestWPF/Properties/Settings.Designer.cs
+++ b/tests/TestWPF/Properties/Settings.Designer.cs
@@ -12,8 +12,8 @@ namespace TestWPF.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.8.0.0")]
-    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.3.0.0")]
+    public sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
         

--- a/tests/TestWPF/TestWPF.csproj
+++ b/tests/TestWPF/TestWPF.csproj
@@ -1,11 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFrameworks>net452;net40;net35</TargetFrameworks>
+    <TargetFrameworks>net452;net40;net35;netcoreapp3.0</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <StartupObject />
     <Authors />
     <Copyright>Copyright ©  2012</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
+    <UseWpf>True</UseWpf>
   </PropertyGroup>
 
   <!-- This is necessary, otherwise it'll default to x86 at least if OutputType is WinExe -->
@@ -14,31 +15,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="System" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Core" />
-    <Reference Condition="'$(TargetFramework)' != 'net35'" Include="System.Xaml" />
-    <Reference Include="WindowsBase" />
-
     <ProjectReference Include="..\..\src\XAMLMarkupExtensions.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <!-- App.xaml -->
-    <ApplicationDefinition Include="App.xaml" SubType="Designer" Generator="MSBuild:Compile" />
-
-    <!-- XAML elements -->
-    <Page Include="**\*.xaml" Exclude="App.xaml" SubType="Designer" Generator="MSBuild:Compile" />
-    <Compile Update="**\*.xaml.cs" SubType="Code" DependentUpon="%(Filename)" />
-
     <!-- Properties\Resources.resx -->
     <EmbeddedResource Update="Properties\Resources.resx" Generator="ResXFileCodeGenerator" LastGenOutput="Resources.Designer.cs" />
     <Compile Update="Properties\Resources.Designer.cs" DesignTime="True" AutoGen="True" DependentUpon="Resources.resx" />
 
     <!-- Properties\Settings.settings -->
-    <None Update="Properties\Settings.settings" Generator="SettingsSingleFileGenerator" LastGenOutput="Settings.Designer.cs" />
-    <Compile Update="Properties\Settings.Designer.cs" DesignTime="True" AutoGen="True" DependentUpon="Settings.settings" />
+    <None Update="Properties\Settings.settings" Generator="PublicSettingsSingleFileGenerator" LastGenOutput="Settings.Designer.cs" />
+    <Compile Update="Properties\Settings.Designer.cs" DesignTime="True" AutoGen="True" DependentUpon="Settings.settings">
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+    </Compile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This pull requests adds support for .NET Core 3.0. It also fixes a bug for the test application when running .NET 3.5.

By changing the project SDK to `Microsoft.NET.Sdk.WindowsDesktop` some references could be removed.