### PR TITLE
Support .Net Core 3.1 (netcoreapp3.1)

### DIFF
--- a/src/XAMLMarkupExtensions.csproj
+++ b/src/XAMLMarkupExtensions.csproj
@@ -1,7 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
-		<TargetFrameworks>net452;net40;net35;netcoreapp3.0</TargetFrameworks>
-		<AssemblyTitle>XAMLMarkupExtensions</AssemblyTitle>
+		<TargetFrameworks>net452;net40;net35;netcoreapp3.1</TargetFrameworks>
+    <UseWPF>True</UseWPF>
+    <AutoGenerateBindingRedirects Condition="$(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('net3'))">true</AutoGenerateBindingRedirects>
+    <AssemblyTitle>XAMLMarkupExtensions</AssemblyTitle>
 		<AssemblyName>XAMLMarkupExtensions</AssemblyName>
 		<RootNamespace>XAMLMarkupExtensions</RootNamespace>
 		<Version>$(GitVersion_NuGetVersion)</Version>
@@ -27,8 +29,10 @@
 		<DelaySign>false</DelaySign>
 		<PublicSign>true</PublicSign>
 		<AssemblyOriginatorKeyFile>public.snk</AssemblyOriginatorKeyFile>
+    <!--Workaround for Error	MSB4216	Could not run the "GenerateResource" -->
+    <GenerateResourceMSBuildArchitecture>CurrentArchitecture</GenerateResourceMSBuildArchitecture>
 	</PropertyGroup>
-
+  
 	<Choose>
 		<When Condition="'$(Configuration)' == 'Release'">
 			<PropertyGroup>
@@ -41,8 +45,9 @@
 			</PropertyGroup>
 		</Otherwise>
 	</Choose>
-
-	<ItemGroup>
+  
+  <!--References for .Net Framwork 4 and 35-->
+	<ItemGroup Condition="$(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('net3'))">
 		<Reference Include="PresentationCore" />
 		<Reference Include="PresentationFramework" />
 		<Reference Include="System" />
@@ -52,7 +57,15 @@
 		<Reference Include="System.Xml.Linq" />
 		<Reference Include="System.Xml" />
 		<Reference Include="WindowsBase" />
+	</ItemGroup>
+  
+  <!--References for .Net Core 3.1-->
+	<ItemGroup Condition="$(TargetFramework.StartsWith('netcore'))">
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="3.1.0" />
+	</ItemGroup>
 
+  <!--PackageReference for all framworks-->
+	<ItemGroup>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
 		<PackageReference Include="GitVersionTask" Version="5.1.1" PrivateAssets="All" />
 	</ItemGroup>

--- a/src/XAMLMarkupExtensions.sln
+++ b/src/XAMLMarkupExtensions.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27428.2043
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29609.76
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XAMLMarkupExtensions", "XAMLMarkupExtensions.csproj", "{D6A34739-E9E5-4E5D-BCF2-E36FAC2FCE44}"
 EndProject
@@ -25,16 +25,6 @@ Global
 		{D6A34739-E9E5-4E5D-BCF2-E36FAC2FCE44}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{D6A34739-E9E5-4E5D-BCF2-E36FAC2FCE44}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{D6A34739-E9E5-4E5D-BCF2-E36FAC2FCE44}.Release|x86.ActiveCfg = Release|Any CPU
-		{1413BA2C-6CAF-4F1D-8A05-8AC06A1DB39F}.Debug|Any CPU.ActiveCfg = Debug|x86
-		{1413BA2C-6CAF-4F1D-8A05-8AC06A1DB39F}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{1413BA2C-6CAF-4F1D-8A05-8AC06A1DB39F}.Debug|Mixed Platforms.Build.0 = Debug|x86
-		{1413BA2C-6CAF-4F1D-8A05-8AC06A1DB39F}.Debug|x86.ActiveCfg = Debug|x86
-		{1413BA2C-6CAF-4F1D-8A05-8AC06A1DB39F}.Debug|x86.Build.0 = Debug|x86
-		{1413BA2C-6CAF-4F1D-8A05-8AC06A1DB39F}.Release|Any CPU.ActiveCfg = Release|x86
-		{1413BA2C-6CAF-4F1D-8A05-8AC06A1DB39F}.Release|Mixed Platforms.ActiveCfg = Release|x86
-		{1413BA2C-6CAF-4F1D-8A05-8AC06A1DB39F}.Release|Mixed Platforms.Build.0 = Release|x86
-		{1413BA2C-6CAF-4F1D-8A05-8AC06A1DB39F}.Release|x86.ActiveCfg = Release|x86
-		{1413BA2C-6CAF-4F1D-8A05-8AC06A1DB39F}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tests/TestWPF/Properties/Resources.Designer.cs
+++ b/tests/TestWPF/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace TestWPF.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/tests/TestWPF/Properties/Settings.Designer.cs
+++ b/tests/TestWPF/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace TestWPF.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.8.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.4.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/tests/TestWPF/TestWPF.csproj
+++ b/tests/TestWPF/TestWPF.csproj
@@ -1,11 +1,17 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFrameworks>net452;net40;net35</TargetFrameworks>
+    <TargetFrameworks>net452;net40;net35;netcoreapp3.1</TargetFrameworks>
     <OutputType>WinExe</OutputType>
-    <StartupObject />
+    <UseWPF>True</UseWPF>
+    <AutoGenerateBindingRedirects Condition="$(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('net3'))">true</AutoGenerateBindingRedirects>
+    <DefineConstants Condition="$(TargetFramework.StartsWith('netcore'))">NETCORE</DefineConstants>
+
+    <StartupObject>TestWPF.App</StartupObject>
     <Authors />
     <Copyright>Copyright ©  2012</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
+    <!--Workaround for Error	MSB4216	Could not run the "GenerateResource" -->
+    <GenerateResourceMSBuildArchitecture>CurrentArchitecture</GenerateResourceMSBuildArchitecture>
   </PropertyGroup>
 
   <!-- This is necessary, otherwise it'll default to x86 at least if OutputType is WinExe -->
@@ -13,7 +19,8 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
-  <ItemGroup>
+  <!--References for .Net Framwork 4 and 35-->
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('net3'))">
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
@@ -21,24 +28,34 @@
     <Reference Include="System.Core" />
     <Reference Condition="'$(TargetFramework)' != 'net35'" Include="System.Xaml" />
     <Reference Include="WindowsBase" />
+  </ItemGroup>
 
+  <!--References for .Net Core 3.1-->
+  <ItemGroup Condition="$(TargetFramework.StartsWith('netcore'))">
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="3.1.0" />
+  </ItemGroup>
+
+  <!--PackageReference for all framworks-->
+  <ItemGroup>
     <ProjectReference Include="..\..\src\XAMLMarkupExtensions.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <!-- App.xaml -->
-    <ApplicationDefinition Include="App.xaml" SubType="Designer" Generator="MSBuild:Compile" />
+     <!--App.xaml--> 
+    <!--<ApplicationDefinition Include="App.xaml" SubType="Designer" Generator="MSBuild:Compile" />-->
 
-    <!-- XAML elements -->
-    <Page Include="**\*.xaml" Exclude="App.xaml" SubType="Designer" Generator="MSBuild:Compile" />
-    <Compile Update="**\*.xaml.cs" SubType="Code" DependentUpon="%(Filename)" />
+     <!--XAML elements--> 
+    <!--<Page Include="**\*.xaml" Exclude="App.xaml" SubType="Designer" Generator="MSBuild:Compile" />
+    <Compile Update="**\*.xaml.cs" SubType="Code" DependentUpon="%(Filename)" />-->
 
-    <!-- Properties\Resources.resx -->
-    <EmbeddedResource Update="Properties\Resources.resx" Generator="ResXFileCodeGenerator" LastGenOutput="Resources.Designer.cs" />
-    <Compile Update="Properties\Resources.Designer.cs" DesignTime="True" AutoGen="True" DependentUpon="Resources.resx" />
+     <!--Properties\Resources.resx--> 
+    <!--<EmbeddedResource Update="Properties\Resources.resx" Generator="ResXFileCodeGenerator" LastGenOutput="Resources.Designer.cs" />
+    <Compile Update="Properties\Resources.Designer.cs" DesignTime="True" AutoGen="True" DependentUpon="Resources.resx" />-->
 
-    <!-- Properties\Settings.settings -->
+     <!--Properties\Settings.settings--> 
     <None Update="Properties\Settings.settings" Generator="SettingsSingleFileGenerator" LastGenOutput="Settings.Designer.cs" />
-    <Compile Update="Properties\Settings.Designer.cs" DesignTime="True" AutoGen="True" DependentUpon="Settings.settings" />
+    <Compile Update="Properties\Settings.Designer.cs" DesignTime="True" AutoGen="True" DependentUpon="Settings.settings">
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+    </Compile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Added support to .Net Core 3.1 by adding `netcoreapp3.1` as a TargetFramework and applied some fixes for it.

All supported frameworks Tested and working fine :)

next to support .Net Core 3.1 in [WPFLocalizationExtension](https://github.com/XAMLMarkupExtensions/WPFLocalizationExtension)
