### PR TITLE
Step 1. Improved searching target in targetObjects

### DIFF
--- a/src/Base/WeakReferenceKey.cs
+++ b/src/Base/WeakReferenceKey.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Security.Permissions;
+
+namespace XAMLMarkupExtensions.Base
+{
+    /// <summary>
+    /// Class for using <see cref="WeakReference" /> as a key in <see cref="Dictionary{TKey,TValue}" />.
+    /// It allows use search by comparing <see cref="WeakReference.Target" /> and keeps HashCode immutable.
+    /// </summary>
+    [Serializable]
+    [SecurityPermission(SecurityAction.InheritanceDemand, Flags = SecurityPermissionFlag.UnmanagedCode)]
+    internal class WeakReferenceKey : WeakReference
+    {
+        private readonly int _hashCode;
+
+        /// <summary>
+        /// Create new instance of <see cref="WeakReferenceKey" />.
+        /// </summary>
+        /// <param name="target">Target object for weak reference.</param>
+        public WeakReferenceKey(object target) : base(target)
+        {
+            _hashCode = target.GetHashCode();
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((WeakReferenceKey) obj);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return _hashCode;
+        }
+
+        /// <summary>
+        /// Compare to another object.
+        /// </summary>
+        /// <param name="other">Other object for comparing.</param>
+        /// <returns>
+        /// <see langwrod="true" /> if objects are equal, <see langword="false" /> otherwise.
+        /// </returns>
+        protected bool Equals(WeakReferenceKey other)
+        {
+            return Target == other.Target;
+        }
+    }
+}


### PR DESCRIPTION
First step of #54

There are two places in `NestedMarkupExtension` where we look through all `targetObjects` dictionary for searching `targetObject`.  Creating custom comparer of targets for `WeakReference` impossible, beacause after collecting Target by `GC`, `WeakReference` will change its HashCode (Target will be null).
So I created another class inherited from `WeakReference` which keep HashCode immutable and allows compare `WeakReferenceKey` by its Target.

Complexity of search target object decrease from O(N) to O(logN). Total comlexity of `ProvideValue` method decrease from O(MN) to O(M * logN).