### PR TITLE
Allows use nested markup extension inside Binding source and Setter

### DIFF
--- a/src/Base/BindingValueProvider.cs
+++ b/src/Base/BindingValueProvider.cs
@@ -8,7 +8,7 @@ namespace XAMLMarkupExtensions.Base
     /// Some properties are sealing (Setter.Value and Binding.Source) and cannot change, so
     /// if we use such provider, it stay same but it's value free to change.
     /// </summary>
-    public class BindingValueProvider : INotifyPropertyChanged
+    internal class BindingValueProvider : INotifyPropertyChanged
     {
         /// <summary>
         /// Property info of <see cref="Value" /> property.

--- a/src/Base/BindingValueProvider.cs
+++ b/src/Base/BindingValueProvider.cs
@@ -1,0 +1,44 @@
+﻿using System.ComponentModel;
+using System.Reflection;
+
+namespace XAMLMarkupExtensions.Base
+{
+    /// <summary>
+    /// Special class which use as value provider for bindings.
+    /// Some properties are sealing (Setter.Value and Binding.Source) and cannot change, so
+    /// if we use such provider, it stay same but it's value free to change.
+    /// </summary>
+    public class BindingValueProvider : INotifyPropertyChanged
+    {
+        /// <summary>
+        /// Property info of <see cref="Value" /> property.
+        /// </summary>
+        public static PropertyInfo ValueProperty = typeof(BindingValueProvider).GetProperty(nameof(Value));
+
+        private object _value;
+
+        /// <summary>
+        /// Providing value.
+        /// </summary>
+        public object Value
+        {
+            get => _value;
+            set
+            {
+                _value = value;
+                OnPropertyChanged(nameof(Value));
+            }
+        }
+
+        /// <inheritdoc />
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary>
+        /// Raise <see cref="PropertyChanged" /> event.
+        /// </summary>
+        protected virtual void OnPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}


### PR DESCRIPTION
Related with discussion in [this issue](https://github.com/XAMLMarkupExtensions/WPFLocalizationExtension/issues/257)

This PR doesn't allow pass `Provider` to `Binding`, but it's allow use LocExtension inside Setter.Value and Binding.Source.

**Sample:**
``` xaml
<TextBlock Name="MyLabel3" FontSize="20" HorizontalAlignment="Center">
    <TextBlock.Text>
        <MultiBinding Converter="{lex:StringFormatConverter}" >
            <Binding Source="{lex:Loc HelloWorldWPF:Ressourcen:MyLabel2}" />
            <Binding Path="Hours" FallbackValue=""/>
        </MultiBinding>
    </TextBlock.Text>
</TextBlock>

<CheckBox Name="CheckBox" Content="Change text" />
<TextBlock FontSize="20">
    <TextBlock.Style>
        <Style TargetType="TextBlock">
            <Setter Property="Text" Value="{lex:Loc en}" />

            <Style.Triggers>
                <DataTrigger Binding="{Binding ElementName=CheckBox, Path=IsChecked}" Value="True">
                    <Setter Property="Text" Value="{lex:Loc de}" />
                </DataTrigger>
            </Style.Triggers>
        </Style>
    </TextBlock.Style>
</TextBlock>
```
![BindingAndSetters](https://user-images.githubusercontent.com/6525732/83718788-303aab80-a64f-11ea-9928-81b7d7c4d813.gif)

**How it's working**
If target object is a `Binding`, `NestedMarkupExtension` can be set as source. At this case we reconfigure Binding and return special object which can be provided one time and can changing. `FormatOutput` work and change only this specific object.
If target object is `Setter` - we can return new Binding which configure as sample upper.

**Memory leak**
Memory leak testing required. It should not be, but I'm not sure.

**P.S.**
It seems to me `DynBindingExtension` do something similar, but I don't how it works.