### PR TITLE
Created performance tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ _ReSharper*/
 *.vs
 
 fullkey.snk
+
+# Jetbrain Rider Cache
+.idea/

--- a/tests/Tests.sln
+++ b/tests/Tests.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XAMLMarkupExtensions", "..\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestWPF", "TestWPF\TestWPF.csproj", "{1413BA2C-6CAF-4F1D-8A05-8AC06A1DB39F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XAMLMarkupExtensions.PerformanceTests", "XAMLMarkupExtensions.PerformanceTests\XAMLMarkupExtensions.PerformanceTests.csproj", "{51BA4700-7209-4999-B5E4-4DB3C4415A1D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{1413BA2C-6CAF-4F1D-8A05-8AC06A1DB39F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1413BA2C-6CAF-4F1D-8A05-8AC06A1DB39F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1413BA2C-6CAF-4F1D-8A05-8AC06A1DB39F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{51BA4700-7209-4999-B5E4-4DB3C4415A1D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{51BA4700-7209-4999-B5E4-4DB3C4415A1D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{51BA4700-7209-4999-B5E4-4DB3C4415A1D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{51BA4700-7209-4999-B5E4-4DB3C4415A1D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tests/XAMLMarkupExtensions.PerformanceTests/Program.cs
+++ b/tests/XAMLMarkupExtensions.PerformanceTests/Program.cs
@@ -1,0 +1,16 @@
+﻿namespace XAMLMarkupExtensions.PerformanceTests
+{
+    #region Uses
+    using BenchmarkDotNet.Running;
+    using Tests;
+    #endregion
+
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var summary = BenchmarkRunner.Run<ProvideValueTests>();
+            //var summary = BenchmarkRunner.Run<CleanupTest>();
+        }
+    }
+}

--- a/tests/XAMLMarkupExtensions.PerformanceTests/TestEntities/TargetProvider.cs
+++ b/tests/XAMLMarkupExtensions.PerformanceTests/TestEntities/TargetProvider.cs
@@ -1,0 +1,37 @@
+﻿namespace XAMLMarkupExtensions.PerformanceTests.TestEntities
+{
+    #region Uses
+    using System;
+    using System.Windows.Markup;
+    #endregion
+
+    /// <summary>
+    /// Class can pass as <see cref="IServiceProvider" /> to <see cref="MarkupExtension.ProvideValue" /> method.
+    /// </summary>
+    public class TargetProvider : IServiceProvider, IProvideValueTarget
+    {
+        /// <inheritdoc />
+        public object TargetObject { get; }
+
+        /// <inheritdoc />
+        public object TargetProperty { get; }
+
+        /// <summary>
+        /// Create <see cref="TargetProvider" /> instance with specified target and property.
+        /// </summary>
+        public TargetProvider(object targetObject, object targetProperty)
+        {
+            TargetObject = targetObject;
+            TargetProperty = targetProperty;
+        }
+
+        /// <inheritdoc />
+        public object GetService(Type serviceType)
+        {
+            if (serviceType == typeof(IProvideValueTarget))
+                return this;
+
+            return null;
+        }
+    }
+}

--- a/tests/XAMLMarkupExtensions.PerformanceTests/TestEntities/TestExtension.cs
+++ b/tests/XAMLMarkupExtensions.PerformanceTests/TestEntities/TestExtension.cs
@@ -1,0 +1,24 @@
+﻿namespace XAMLMarkupExtensions.PerformanceTests.TestEntities
+{
+    #region Uses
+    using Base;
+    #endregion
+
+    /// <summary>
+    /// Test extension which implements NestedMarkupExtension.
+    /// </summary>
+    public class TestExtension : NestedMarkupExtension
+    {
+        /// <inheritdoc />
+        public override object FormatOutput(TargetInfo endPoint, TargetInfo info)
+        {
+            return string.Empty;
+        }
+
+        /// <inheritdoc />
+        protected override bool UpdateOnEndpoint(TargetInfo endpoint)
+        {
+            return true;
+        }
+    }
+}

--- a/tests/XAMLMarkupExtensions.PerformanceTests/TestEntities/TestTargetObject.cs
+++ b/tests/XAMLMarkupExtensions.PerformanceTests/TestEntities/TestTargetObject.cs
@@ -1,0 +1,21 @@
+﻿namespace XAMLMarkupExtensions.PerformanceTests.TestEntities
+{
+    #region Uses
+    using System.Windows;
+    #endregion
+
+    /// <summary>
+    /// Simple dependency object.
+    /// </summary>
+    public class TestTargetObject : DependencyObject
+    {
+        public static readonly DependencyProperty ValueProperty = DependencyProperty.Register(
+            nameof(Value), typeof(string), typeof(TestTargetObject), new PropertyMetadata(default(string)));
+
+        public string Value
+        {
+            get => (string) GetValue(ValueProperty);
+            set => SetValue(ValueProperty, value);
+        }
+    }
+}

--- a/tests/XAMLMarkupExtensions.PerformanceTests/Tests/CleanupTest.cs
+++ b/tests/XAMLMarkupExtensions.PerformanceTests/Tests/CleanupTest.cs
@@ -1,0 +1,89 @@
+﻿using XAMLMarkupExtensions.Base;
+
+namespace XAMLMarkupExtensions.PerformanceTests.Tests
+{
+    #region Uses
+    using System;
+    using System.Collections.Generic;
+    using BenchmarkDotNet.Attributes;
+    using TestEntities;
+    #endregion
+
+    [MemoryDiagnoser]
+    public class CleanupTest
+    {
+        private Dictionary<TestExtension, List<TestTargetObject>> _extensions;
+
+        /// <summary>
+        /// Count of created extensions.
+        /// </summary>
+        [Params(100)]
+        public int ExtensionsCount;
+
+        /// <summary>
+        /// Count of targets for each extension.
+        /// </summary>
+        [Params(100)]
+        public int ExtensionTargetsCount;
+
+        [Benchmark]
+        public void ReferencesCleanup()
+        {
+            // Remove half of dependencies.
+            foreach (var targetObjects in _extensions.Values)
+            {
+                var middle = targetObjects.Count / 2;
+                targetObjects.RemoveRange(middle, targetObjects.Count - middle);
+            }
+
+            // Force GC, so part of weak references will be dead.
+            GC.Collect(2, GCCollectionMode.Forced);
+
+            // Create new extension and provide value. Inside dead weak references will be removed.
+            var extension = new TestExtension();
+            var target = new TestTargetObject();
+            var serviceProvider = new TargetProvider(target, TestTargetObject.ValueProperty);
+            extension.ProvideValue(serviceProvider);
+        }
+
+        /// <summary>
+        /// Fill internal list of listeners.
+        /// </summary>
+        [IterationSetup]
+        public void Setup()
+        {
+            _extensions = new Dictionary<TestExtension, List<TestTargetObject>>();
+            for (int extensionIndex = 0; extensionIndex < ExtensionsCount; extensionIndex++)
+            {
+                var extension = new TestExtension();
+                _extensions.Add(extension, new List<TestTargetObject>());
+
+                for (int targetIndex = 0; targetIndex < ExtensionTargetsCount; targetIndex++)
+                {
+                    var target = new TestTargetObject();
+                    var serviceProvider = new TargetProvider(target, TestTargetObject.ValueProperty);
+                    extension.ProvideValue(serviceProvider);
+
+                    _extensions[extension].Add(target);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Remove all extensions from internal list.
+        /// </summary>
+        [IterationCleanup]
+        public void Cleanup()
+        {
+            foreach (var (extension, _) in _extensions)
+            {
+                extension.Dispose();
+                
+                // TODO Remove after correct dispose realization.
+                ObjectDependencyManager.CleanUp(extension);
+            }
+
+            _extensions.Clear();
+        }
+    }
+}

--- a/tests/XAMLMarkupExtensions.PerformanceTests/Tests/ProvideValueTests.cs
+++ b/tests/XAMLMarkupExtensions.PerformanceTests/Tests/ProvideValueTests.cs
@@ -1,0 +1,70 @@
+﻿namespace XAMLMarkupExtensions.PerformanceTests.Tests
+{
+    #region Uses
+    using System.Collections.Generic;
+    using BenchmarkDotNet.Attributes;
+    using Base;
+    using TestEntities;
+    #endregion
+
+    [MemoryDiagnoser]
+    public class ProvideValueTests
+    {
+        private List<TestExtension> _extensions;
+        private List<TestTargetObject> _targets;
+
+        /// <summary>
+        /// Test <see cref="NestedMarkupExtension.ProvideValue" /> method.
+        /// </summary>
+        /// <param name="extensionsCount">Count of created extensions.</param>
+        /// <param name="extensionTargetsCount">Count of targets for each extension.</param>
+        [Benchmark]
+        [Arguments(3000, 1)]
+        [Arguments(50, 100)]
+        public void ProvideValue(int extensionsCount, int extensionTargetsCount)
+        {
+            Setup(extensionsCount, extensionTargetsCount);
+
+            for (int extensionIndex = 0; extensionIndex < extensionsCount; extensionIndex++)
+            {
+                var extension = new TestExtension();
+                _extensions.Add(extension);
+
+                for (int targetIndex = 0; targetIndex < extensionTargetsCount; targetIndex++)
+                {
+                    var target = new TestTargetObject();
+                    var serviceProvider = new TargetProvider(target, TestTargetObject.ValueProperty);
+                    extension.ProvideValue(serviceProvider);
+                    _targets.Add(target);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Initialize lists.
+        /// </summary>
+        public void Setup(int extensionsCount, int extensionTargetsCount)
+        {
+            _extensions = new List<TestExtension>(extensionsCount);
+            _targets = new List<TestTargetObject>(extensionsCount * extensionTargetsCount);
+        }
+
+        /// <summary>
+        /// Remove all extensions from internal list.
+        /// </summary>
+        [IterationCleanup]
+        public void Cleanup()
+        {
+            foreach (var extension in _extensions)
+            {
+                extension.Dispose();
+                
+                // TODO Remove after correct dispose realization.
+                ObjectDependencyManager.CleanUp(extension);
+            }
+
+            _extensions.Clear();
+            _targets.Clear();
+        }
+    }
+}

--- a/tests/XAMLMarkupExtensions.PerformanceTests/XAMLMarkupExtensions.PerformanceTests.csproj
+++ b/tests/XAMLMarkupExtensions.PerformanceTests/XAMLMarkupExtensions.PerformanceTests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\XAMLMarkupExtensions.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This is part of #74 PR, which contains performance tests based on `BechmarkDotNet`.
I have tried to avoid influence of tests to each over without changing `Dispose` of `NestedMarkupExtension`. Also I didn't remove `CleanupTest`, because I'd like to improve it in future.
Also I a bit change .gitignore for Rider IDE support.