### PR TITLE
Added check Setter.Property for null value

### DIFF
--- a/src/Base/NestedMarkupExtension.cs
+++ b/src/Base/NestedMarkupExtension.cs
@@ -201,7 +201,9 @@ namespace XAMLMarkupExtensions.Base
             {
                 targetObject = new BindingValueProvider();
                 targetProperty = BindingValueProvider.ValueProperty;
-                targetPropertyType = setter.Property.PropertyType;
+                // If Setter.TargetName is used then Setter.Property would be null.
+                // We cannot define which type used in this case.
+                targetPropertyType = setter.Property?.PropertyType ?? typeof(object);
 
                 overriddenResult = new Binding(nameof(BindingValueProvider.Value))
                 {


### PR DESCRIPTION
Fixed #101 

For some reasons if we create setter with defined `TargetName`, then `Property` will be null. I couldn't find any information about this behavior. So i just added check for `null`. 