### PR TITLE
Cleaning dead references after adding new

### DIFF
--- a/src/Base/ObjectDependencyManager.cs
+++ b/src/Base/ObjectDependencyManager.cs
@@ -58,9 +58,6 @@ namespace XAMLMarkupExtensions.Base
         [MethodImpl(MethodImplOptions.Synchronized)]
         public static bool AddObjectDependency(WeakReference weakRefDp, object objToHold)
         {
-            // run the clean up to ensure that only objects are watched they are realy still alive
-            CleanUp();
-
             // if the objToHold is null, we cannot handle this afterwards.
             if (objToHold == null)
             {
@@ -110,6 +107,9 @@ namespace XAMLMarkupExtensions.Base
                 }
             }
 
+            // run the clean up to ensure that only objects are watched they are realy still alive
+            CleanUp();
+            
             // return the status of the registration
             return itemRegistered;
         }


### PR DESCRIPTION
**Problem**
If the previous dependency of the target was dead and we add a new one then `OnAllDependenciesRemoved` is called and `NestedMarkupExtension` removes this new dependency. After this we cannot work with it and get exception.

**Fixed**
`CleanUp` moved to the end of the method, so we will have two dependencies and remove only the old one.

Thanks @Psykobal for finding the problem and solution